### PR TITLE
Fix corner cases and input validation

### DIFF
--- a/motor_controller.orogen
+++ b/motor_controller.orogen
@@ -43,9 +43,10 @@ task_context 'PIDTask' do
     # The internal state of the PID controllers
     output_port 'pid_states', 'std/vector<motor_controller/PIDState>'
 
-    exception_states :UNINITIALIZED_INPUT_MODE
+
     exception_states :WRONG_INPUT_COMMAND_SIZE
     exception_states :WRONG_STATUS_SIZE
+    exception_states :INVALID_INPUT_COMMAND
     exception_states :INVALID_STATUS_SAMPLE
 
     port_driven :status_samples

--- a/motor_controller.orogen
+++ b/motor_controller.orogen
@@ -46,6 +46,7 @@ task_context 'PIDTask' do
     exception_states :UNINITIALIZED_INPUT_MODE
     exception_states :WRONG_INPUT_COMMAND_SIZE
     exception_states :WRONG_STATUS_SIZE
+    exception_states :INVALID_STATUS_SAMPLE
 
     port_driven :status_samples
 end

--- a/tasks/PIDTask.cpp
+++ b/tasks/PIDTask.cpp
@@ -36,9 +36,7 @@ bool PIDTask::configureHook()
     mStatus.resize(size);
     mInputCommand.resize(size);
     mOutputCommand.resize(size);
-    _out_command.setDataSample(mOutputCommand);
     mPIDState.resize(size);
-    _pid_states.setDataSample(mPIDState);
     return true;
 }
 

--- a/tasks/PIDTask.cpp
+++ b/tasks/PIDTask.cpp
@@ -122,6 +122,7 @@ void PIDTask::updateHook()
                 input_target,
                 mStatus.time);
 
+        mOutputCommand[i] = base::JointState();
         mOutputCommand[i].setField(output_domain, pid_output);
         mPIDState[i] = mPIDs[i].getState();
     }

--- a/tasks/PIDTask.cpp
+++ b/tasks/PIDTask.cpp
@@ -89,7 +89,20 @@ void PIDTask::updateHook()
 
     for (size_t i = 0; i < mStatus.size(); ++i)
     {
-        JointState::MODE input_domain = mInputCommand[i].getMode();
+        JointState::MODE input_domain = JointState::UNSET;
+        try {
+            input_domain = mInputCommand[i].getMode();
+            if (input_domain == JointState::UNSET) {
+                LOG_ERROR_S << "command.elements[" << i << "] invalid: "
+                            << "no fields are set" << std::endl;
+                return exception(INVALID_INPUT_COMMAND);
+            }
+        }
+        catch (std::runtime_error const& e) {
+            LOG_ERROR_S << "command.elements[" << i << "] invalid: "
+                        << e.what() << std::endl;
+            return exception(INVALID_INPUT_COMMAND);
+        }
         float input_target = mInputCommand[i].getField(input_domain);
         float input_state  = mStatus[i].getField(input_domain);
 

--- a/tasks/PIDTask.cpp
+++ b/tasks/PIDTask.cpp
@@ -93,6 +93,13 @@ void PIDTask::updateHook()
         float input_target = mInputCommand[i].getField(input_domain);
         float input_state  = mStatus[i].getField(input_domain);
 
+        if (base::isUnknown(input_state)) {
+            LOG_ERROR_S
+                << "Status sample does not contain the necessary information"
+                << std::endl;
+            return exception(INVALID_STATUS_SAMPLE);
+        }
+
         ActuatorSettings const& settings(mSettings[i]);
         JointState::MODE output_domain = settings.output_mode;
 

--- a/tasks/PIDTask.cpp
+++ b/tasks/PIDTask.cpp
@@ -124,6 +124,7 @@ void PIDTask::updateHook()
         mOutputCommand[i].setField(output_domain, pid_output);
         mPIDState[i] = mPIDs[i].getState();
     }
+    mOutputCommand.names = mInputCommand.names;
     _out_command.write(mOutputCommand);
     _pid_states.write(mPIDState);
 }

--- a/test/pid_task_test.rb
+++ b/test/pid_task_test.rb
@@ -7,8 +7,6 @@ describe OroGen.motor_controller.PIDTask do
 
     attr_reader :task
     before do
-        self.expect_execution_default_timeout = 60
-
         @task = syskit_deploy(
             OroGen.motor_controller.PIDTask
                   .deployed_as('pid_task_test')


### PR DESCRIPTION
I want to stress this particular change: dd14ca6 

This seems to be a pretty bad behavior, and I'm not sure whether it is due to the age of the
rtt package in Rock (blocked by the heavy deadlocking introduced in RTT master), or if it
is still present in rtt itself.