### PR TITLE
fix: filled time field in the output command

### DIFF
--- a/tasks/PIDTask.cpp
+++ b/tasks/PIDTask.cpp
@@ -126,6 +126,7 @@ void PIDTask::updateHook()
         mPIDState[i] = mPIDs[i].getState();
     }
     mOutputCommand.names = mInputCommand.names;
+    mOutputCommand.time = base::Time::now();
     _out_command.write(mOutputCommand);
     _pid_states.write(mPIDState);
 }


### PR DESCRIPTION
This pull request addresses an issue where the time field in the output command was not being populated.